### PR TITLE
Issue/4 bump minimal python version 311

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -24,4 +24,4 @@ jobs:
   doc:
     uses: camelot-os/pipeline-python/.github/workflows/doc.yml@v1
     with:
-      python-version: '3.10'
+      python-version: '3.11'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,4 +22,4 @@ jobs:
   lint:
     uses: camelot-os/pipeline-python/.github/workflows/lint.yml@v1
     with:
-      python-version: '3.10'
+      python-version: '3.11'

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -24,7 +24,7 @@ jobs:
   unittest:
     strategy:
       matrix:
-          version: ['3.10', '3.11', '3.12']
+          version: ['3.11', '3.12']
     uses: camelot-os/pipeline-python/.github/workflows/unittest.yml@v1
     with:
       python-version: ${{ matrix.version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "camelot-barbican"
 description = "Camelot-OS build system"
 dynamic = ["version"]
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 readme = "README.md"
 authors = [
   {name = "Florent Valette"},
@@ -45,7 +45,6 @@ classifiers = [
 
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
@@ -86,7 +85,7 @@ tools = [
 [tool.setuptools_scm]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 
 [[tool.mypy.overrides]]
 module = "tomli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "ninja_syntax>1.7",
     "svd2json>=0.1.6",
     "dts-utils>=0.2.0",
-    "tomli>=2.0.1; python_version < '3.11'",
     "referencing>=0.33.0",
     "rich>=13.6",
     "GitPython>=3.1.44",
@@ -83,10 +82,3 @@ tools = [
 ]
 
 [tool.setuptools_scm]
-
-[tool.mypy]
-python_version = "3.11"
-
-[[tool.mypy.overrides]]
-module = "tomli"
-ignore_missing_imports = true

--- a/src/camelot/barbican/_internals/__init__.py
+++ b/src/camelot/barbican/_internals/__init__.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024 Ledger SAS
+# SPDX-FileCopyrightText: 2025 H2Lab
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -30,7 +31,7 @@ One can call internal command with the following:
 
             Returns the Python's :py:type:`argparse.ArgumentParser` for the given internal command
 
-        .. function:: run(argv: T.List[str]) -> None:
+        .. function:: run(argv: list[str]) -> None:
 
             Execute the internal command.
 """

--- a/src/camelot/barbican/_internals/capture_out.py
+++ b/src/camelot/barbican/_internals/capture_out.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024 Ledger SAS
+# SPDX-FileCopyrightText: 2025 H2Lab
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -10,7 +11,6 @@ Execute a random command and capture stdout to file
 
 from argparse import ArgumentParser, REMAINDER
 from pathlib import Path
-import typing as T
 import subprocess
 
 
@@ -28,7 +28,7 @@ def argument_parser() -> ArgumentParser:
     return parser
 
 
-def run(argv: T.List[str]) -> None:
+def run(argv: list[str]) -> None:
     """Execute capture stdout internal command."""
     args = argument_parser().parse_args(argv)
     run_capture_stdout(args.cmdline, args.out)

--- a/src/camelot/barbican/_internals/cargo_config.py
+++ b/src/camelot/barbican/_internals/cargo_config.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024 Ledger SAS
+# SPDX-FileCopyrightText: 2025 H2Lab
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -9,7 +10,6 @@ Add target specific and per apps compile flags in a config.
 
 from argparse import ArgumentParser
 from pathlib import Path
-import typing as T
 
 
 def run_cargo_config(rustargs: Path, target: Path, extra_args: str, outdir: Path) -> None:
@@ -46,7 +46,7 @@ def argument_parser() -> ArgumentParser:
     return parser
 
 
-def run(argv: T.List[str]) -> None:
+def run(argv: list[str]) -> None:
     """Execute gen crate cargo config command."""
     args = argument_parser().parse_args(argv)
     run_cargo_config(args.rustargs_file, args.target_file, args.extra_args, args.outdir)

--- a/src/camelot/barbican/_internals/cargo_install.py
+++ b/src/camelot/barbican/_internals/cargo_install.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024 Ledger SAS
+# SPDX-FileCopyrightText: 2025 H2Lab
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -9,7 +10,6 @@ Add target specific and per apps compile flags in a config.
 
 from argparse import ArgumentParser
 from pathlib import Path
-import typing as T
 
 from .install import run_install, argument_parser as install_argument_parser
 
@@ -32,7 +32,7 @@ def argument_parser() -> ArgumentParser:
     return parser
 
 
-def run(argv: T.List[str]) -> None:
+def run(argv: list[str]) -> None:
     args = argument_parser().parse_args(argv)
     target: str = args.target_file.read_text().splitlines()[0]
     from_dir: Path = (args.from_dir / target / args.profile).resolve(strict=True)

--- a/src/camelot/barbican/_internals/gen_ldscript.py
+++ b/src/camelot/barbican/_internals/gen_ldscript.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024 Ledger SAS
+# SPDX-FileCopyrightText: 2025 H2Lab
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -9,7 +10,6 @@ TODO : documentation
 
 from argparse import ArgumentParser
 from pathlib import Path
-import typing as T
 
 from jinja2 import Environment, BaseLoader
 import json
@@ -56,7 +56,7 @@ def argument_parser() -> ArgumentParser:
     return parser
 
 
-def run(argv: T.List[str]) -> None:
+def run(argv: list[str]) -> None:
     """Execute gen_ldscript internal command."""
     args = argument_parser().parse_args(argv)
     run_gen_ldscript(args.name, args.template, args.layout, args.output)

--- a/src/camelot/barbican/_internals/gen_memory_layout.py
+++ b/src/camelot/barbican/_internals/gen_memory_layout.py
@@ -20,7 +20,7 @@ from ..utils import memory_layout as memory
 from ..utils import align_to, pow2_round_up
 
 
-def _get_project_elves(exelist: list[Path]) -> T.Tuple[SentryElf, list[AppElf]]:
+def _get_project_elves(exelist: list[Path]) -> tuple[SentryElf, list[AppElf]]:
     sentry: SentryElf
     apps: list[AppElf] = []
 
@@ -61,7 +61,7 @@ def _add_kernel_regions(layout: memory.Layout, sentry: SentryElf) -> None:
     )
 
 
-def _add_idle_regions(layout: memory.Layout, sentry: SentryElf) -> T.Tuple[int, int]:
+def _add_idle_regions(layout: memory.Layout, sentry: SentryElf) -> tuple[int, int]:
     idle_text_saddr, idle_text_size = sentry.get_section_info(".idle_task")
     idle_ram_saddr, idle_ram_size = sentry.get_section_info("._idle")
     # XXX: hardcoded name

--- a/src/camelot/barbican/_internals/gen_memory_layout.py
+++ b/src/camelot/barbican/_internals/gen_memory_layout.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024 Ledger SAS
+# SPDX-FileCopyrightText: 2025 H2Lab
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -19,9 +20,9 @@ from ..utils import memory_layout as memory
 from ..utils import align_to, pow2_round_up
 
 
-def _get_project_elves(exelist: list[Path]) -> T.Tuple[SentryElf, T.List[AppElf]]:
+def _get_project_elves(exelist: list[Path]) -> T.Tuple[SentryElf, list[AppElf]]:
     sentry: SentryElf
-    apps: T.List[AppElf] = []
+    apps: list[AppElf] = []
 
     for elf in exelist:
         name = elf.stem
@@ -307,7 +308,7 @@ def argument_parser() -> ArgumentParser:
     return parser
 
 
-def run(argv: T.List[str]) -> None:
+def run(argv: list[str]) -> None:
     """Execute memory_layout internal command."""
     args = argument_parser().parse_args(argv)
 

--- a/src/camelot/barbican/_internals/gen_task_metadata_bin.py
+++ b/src/camelot/barbican/_internals/gen_task_metadata_bin.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024 Ledger SAS
+# SPDX-FileCopyrightText: 2025 H2Lab
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -102,7 +103,7 @@ def argument_parser() -> ArgumentParser:
     return parser
 
 
-def run(argv: T.List[str]) -> None:
+def run(argv: list[str]) -> None:
     args = argument_parser().parse_args(argv)
     # XXX: use builddir as option
     run_gen_task_metadata_bin(

--- a/src/camelot/barbican/_internals/install.py
+++ b/src/camelot/barbican/_internals/install.py
@@ -1,11 +1,11 @@
 # SPDX-FileCopyrightText: 2024 Ledger SAS
+# SPDX-FileCopyrightText: 2025 H2Lab
 #
 # SPDX-License-Identifier: Apache-2.0
 
 from argparse import ArgumentParser, REMAINDER
 from pathlib import Path
 import shutil
-import typing as T
 
 from ..console import console
 
@@ -36,6 +36,6 @@ def argument_parser() -> ArgumentParser:
     return parser
 
 
-def run(argv: T.List[str]) -> None:
+def run(argv: list[str]) -> None:
     args = argument_parser().parse_args(argv)
     run_install(args.from_dir, args.files, args.suffix)

--- a/src/camelot/barbican/_internals/kernel_fixup.py
+++ b/src/camelot/barbican/_internals/kernel_fixup.py
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: 2024 Ledger SAS
+# SPDX-FileCopyrightText: 2025 H2Lab
 #
 # SPDX-License-Identifier: Apache-2.0
 
 from argparse import ArgumentParser
 from pathlib import Path
-import typing as T
 
 from ..relocation.elfutils import SentryElf
 
@@ -36,7 +36,7 @@ def argument_parser() -> ArgumentParser:
     return parser
 
 
-def run(argv: T.List[str]) -> None:
+def run(argv: list[str]) -> None:
     """Execute kernel_fixup internal command."""
     args = argument_parser().parse_args(argv)
     run_kernel_fixup(args.kern_input, args.kern_output, args.metadata)

--- a/src/camelot/barbican/_internals/meson_package_dyndep.py
+++ b/src/camelot/barbican/_internals/meson_package_dyndep.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024 Ledger SAS
+# SPDX-FileCopyrightText: 2025 H2Lab
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -146,7 +147,7 @@ def argument_parser() -> ArgumentParser:
     return parser
 
 
-def run(argv: T.List[str]) -> None:
+def run(argv: list[str]) -> None:
     """Execute meson package dyndep internal command."""
     args = argument_parser().parse_args(argv)
     run_meson_package_dyndep(args.name, args.builddir, args.stagingdir, args.dyndep, args.json)

--- a/src/camelot/barbican/_internals/objcopy.py
+++ b/src/camelot/barbican/_internals/objcopy.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024 Ledger SAS
+# SPDX-FileCopyrightText: 2025 H2Lab
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -6,7 +7,6 @@ from argparse import ArgumentParser
 import json
 from pathlib import Path
 import subprocess
-import typing as T
 
 from ..utils.environment import find_program
 
@@ -47,7 +47,7 @@ def argument_parser() -> ArgumentParser:
     return parser
 
 
-def run(argv: T.List[str]) -> None:
+def run(argv: list[str]) -> None:
     args = argument_parser().parse_args(argv)
 
     objcopy = None

--- a/src/camelot/barbican/_internals/relink_elf.py
+++ b/src/camelot/barbican/_internals/relink_elf.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024 Ledger SAS
+# SPDX-FileCopyrightText: 2025 H2Lab
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -6,7 +7,6 @@ from argparse import ArgumentParser
 import json
 from pathlib import Path
 import subprocess
-import typing as T
 
 
 # XXX: Add an helper module in utils
@@ -57,7 +57,7 @@ def argument_parser() -> ArgumentParser:
     return parser
 
 
-def run(argv: T.List[str]) -> None:
+def run(argv: list[str]) -> None:
     args = argument_parser().parse_args(argv)
     linker_cmdline = None
     if args.mesonintrospect:

--- a/src/camelot/barbican/_internals/srec_cat.py
+++ b/src/camelot/barbican/_internals/srec_cat.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024 Ledger SAS
+# SPDX-FileCopyrightText: 2025 H2Lab
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -21,9 +22,9 @@ _SREC_CAT_FORMAT: T.Dict[str, str] = {
 }
 
 
-def run_srec_cat(inputs: T.List[Path], output: Path, format: str) -> None:
+def run_srec_cat(inputs: list[Path], output: Path, format: str) -> None:
     srec_cat = find_program("srec_cat")
-    cmdline: T.List[str] = [srec_cat]
+    cmdline: list[str] = [srec_cat]
 
     for input in inputs:
         cmdline.extend([str(input.resolve(strict=True)), format])
@@ -47,7 +48,7 @@ def argument_parser() -> ArgumentParser:
     return parser
 
 
-def run(argv: T.List[str]) -> None:
+def run(argv: list[str]) -> None:
     """Execute srec_cat internal command."""
     args = argument_parser().parse_args(argv)
     run_srec_cat(args.inputs, args.output, _SREC_CAT_FORMAT[args.format])

--- a/src/camelot/barbican/_internals/srec_cat.py
+++ b/src/camelot/barbican/_internals/srec_cat.py
@@ -10,14 +10,13 @@ TODO : documentation
 
 from argparse import ArgumentParser
 from pathlib import Path
-import typing as T
 
 import subprocess
 
 from ..utils.environment import find_program
 
 
-_SREC_CAT_FORMAT: T.Dict[str, str] = {
+_SREC_CAT_FORMAT: dict[str, str] = {
     "ihex": "-intel",
 }
 

--- a/src/camelot/barbican/barbican.py
+++ b/src/camelot/barbican/barbican.py
@@ -10,7 +10,6 @@ import os
 import logging
 import pathlib
 import sys
-import typing as T
 
 from .console import console
 from .logger import logger, log_config
@@ -315,7 +314,7 @@ def run_command() -> None:
     args.func(project)
 
 
-def run_internal_command(cmd: str, argv: T.List[str]) -> None:
+def run_internal_command(cmd: str, argv: list[str]) -> None:
     """Run an internal barbican command.
 
     :param cmd: internal command name

--- a/src/camelot/barbican/barbican.py
+++ b/src/camelot/barbican/barbican.py
@@ -1,14 +1,9 @@
 # SPDX-FileCopyrightText: 2023 - 2024 Ledger SAS
+# SPDX-FileCopyrightText: 2025 H2Lab
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# XXX:
-# tomllib is the standard buildt-in toml library since python 3.11
-# prior to 3.11, use tomli instead (reference implementation that became the standard).
-try:
-    import tomllib  # type: ignore
-except ModuleNotFoundError:
-    import tomli as tomllib
+import tomllib
 
 from argparse import ArgumentParser
 import os

--- a/src/camelot/barbican/package/package.py
+++ b/src/camelot/barbican/package/package.py
@@ -7,12 +7,11 @@ import collections.abc
 from pathlib import Path
 
 from functools import lru_cache
-from enum import auto, unique
+from enum import StrEnum, auto, unique
 
 from ..console import console
 from ..logger import logger
 from ..scm import scm_create
-from ..utils import StrEnum
 
 import typing as T
 

--- a/src/camelot/barbican/scm/__init__.py
+++ b/src/camelot/barbican/scm/__init__.py
@@ -2,11 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from enum import auto, unique
+from enum import StrEnum, auto, unique
 import collections.abc
 from pathlib import Path
 from .scm import ScmBaseClass
-from ..utils import StrEnum
 
 
 @unique

--- a/src/camelot/barbican/utils/__init__.py
+++ b/src/camelot/barbican/utils/__init__.py
@@ -6,24 +6,9 @@ import os
 import math
 
 from contextlib import contextmanager
-from enum import Enum
 from pathlib import Path
 
 from ..logger import logger
-
-
-# XXX:
-#  StrEnum is a python 3.11+ feature but as simple as the following.
-try:
-    from enum import StrEnum  # type: ignore
-except ImportError:
-
-    class StrEnum(Enum):  # type: ignore
-        @staticmethod
-        def _generate_next_value_(  # type: ignore
-            name: str, start: int, count: int, last_values: list[str]
-        ) -> str:
-            return name.replace("_", "-").lower()
 
 
 @contextmanager

--- a/src/camelot/barbican/utils/environment.py
+++ b/src/camelot/barbican/utils/environment.py
@@ -19,12 +19,12 @@ def find_program(name: str) -> str: ...
 @T.overload
 def find_program(name: bytes) -> bytes: ...
 @T.overload
-def find_program(name: str, path: T.Optional[Path]) -> str: ...
+def find_program(name: str, path: Path | None) -> str: ...
 @T.overload
-def find_program(name: bytes, path: T.Optional[Path]) -> bytes: ...
+def find_program(name: bytes, path: Path | None) -> bytes: ...
 
 
-def find_program(name: str | bytes, path: T.Optional[Path] = None) -> str | bytes:
+def find_program(name: str | bytes, path: Path | None = None) -> str | bytes:
     if name not in _PROGRAM_CACHE_DICT.keys():
         log = f"Find Program: {name!r}"
         if path:
@@ -60,14 +60,14 @@ class ExeWrapper:
     >>> meson.setup(cross_file="Path/to/crossfile", args=["path/to/builddir"])
     """
 
-    def __init__(self, name: str, path: T.Optional[Path] = None, capture_out: bool = False) -> None:
+    def __init__(self, name: str, path: Path | None = None, capture_out: bool = False) -> None:
         """Initialize a ExeWrapper instance.
 
         Parameters
         ----------
         name: str
             Program name to wrap
-        path: T.Optional[Path]
+        path: Path | None
             Search path for executable, optional.
         capture_out: bool
             Capture stdout as str (system default encoding) if True, False by default.

--- a/src/camelot/barbican/utils/memory_layout.py
+++ b/src/camelot/barbican/utils/memory_layout.py
@@ -29,7 +29,7 @@ class Region:
     permission: Permission = Permission(0)
     start_address: int
     size: int
-    subregions: T.List["Region"] = field(default_factory=list)
+    subregions: list["Region"] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         for f in fields(self):
@@ -37,7 +37,7 @@ class Region:
             value_type = T.cast(type, f.type)
             if value_type is int and isinstance(value, str):
                 object.__setattr__(self, f.name, int(value, 16))
-            elif value_type is T.List["Region"] and all(isinstance(e, dict) for e in value):
+            elif value_type is list["Region"] and all(isinstance(e, dict) for e in value):
                 object.__setattr__(self, f.name, [Region(**e) for e in value])
             elif issubclass(value_type, Enum):
                 object.__setattr__(self, f.name, value_type(value))

--- a/src/camelot/barbican/utils/memory_layout.py
+++ b/src/camelot/barbican/utils/memory_layout.py
@@ -5,12 +5,10 @@
 from dataclasses import dataclass, fields, field, asdict
 from enum import unique, auto, IntFlag
 
-from enum import Enum
+from enum import Enum, StrEnum
 import json
 from pathlib import Path
 import typing as T
-
-from . import StrEnum
 
 
 @dataclass(kw_only=True, frozen=True)

--- a/src/camelot/barbican/utils/pathhelper.py
+++ b/src/camelot/barbican/utils/pathhelper.py
@@ -3,13 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass, field, asdict
-from enum import unique, auto
+from enum import StrEnum, unique, auto
 from functools import lru_cache
 import json
 from pathlib import Path
 from typing import ClassVar
 
-from . import StrEnum
 from ..console import console
 
 


### PR DESCRIPTION
Bump minimal version 3.10 -> 3.11

Closes #4 

- [x] update pyproject
- [x] update workflow
- [x] remove StrEnum quirk
- [x] remove tomllib/tomli quirk
- [x] update typechecking (remove old 3.9/3.10 only syntaxe) 