### PR TITLE
Fix crossfile path

### DIFF
--- a/src/camelot/barbican/barbican.py
+++ b/src/camelot/barbican/barbican.py
@@ -101,7 +101,9 @@ class Project:
         ninja.add_barbican_rules()
         ninja.add_barbican_internals_rules()
         ninja.add_barbican_targets(self)
-        ninja.add_barbican_cross_file(pathlib.Path(self._toml["crossfile"]))
+        ninja.add_barbican_cross_file(
+            (pathlib.Path(self.path.project_dir) / self._toml["crossfile"]).resolve(strict=True)
+        )
         dts_include_dirs = []
         for p in self._packages:
             dts_include_dirs.extend(p.dts_include_dirs)

--- a/src/camelot/barbican/buildsys/ninja_backend.py
+++ b/src/camelot/barbican/buildsys/ninja_backend.py
@@ -94,7 +94,7 @@ class NinjaGenFile:
 
     def add_barbican_cross_file(self, crossfile: Path) -> None:
         self._ninja.newline()
-        self._ninja.variable("crossfile", str(crossfile))
+        self._ninja.variable("crossfile", str(crossfile.resolve(strict=True)))
 
     def add_internal_gen_memory_layout_target(
         self,


### PR DESCRIPTION
In `project.toml` allows to set crossfile variable with a relative path to the configuration file. The resolution of the path is done in `add_barbican_cross_file` function and the call to the function